### PR TITLE
Pre-build step for replacing relative for absolute URLs in the README

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,0 +1,44 @@
+import git
+import re
+
+from setup import read_readme
+
+
+def write_readme(readme, filename="README.md"):
+    with open(filename, "w") as f:
+        f.write(readme)
+
+
+def get_repo_info():
+    info = dict()
+    repo = git.Repo(".git")
+    info['url'] = repo.remotes.origin.url
+    m = re.match(r"git@github.com:(.*)/(.*).git", info['url'])
+    info['namespace'] = m.group(1)
+    info['project'] = m.group(2)
+    info['commit'] = repo.head.commit.hexsha
+    info['branch'] = None
+    info['tag'] = None
+    if repo.head.is_detached:
+        info['tag'] = next((tag.name for tag in repo.tags if tag.commit == repo.head.commit))
+    else:
+        info['branch'] = repo.active_branch.name
+    return info
+
+
+def assemble_github_content_url(namespace, project, branch, tag, commit, **kwargs):
+    version = branch or tag or commit
+    content_url = f"https://raw.githubusercontent.com/{namespace}/{project}/{version}"
+    return content_url
+
+
+def get_readme_with_github_urls():
+    readme = read_readme()
+    repo_info = get_repo_info()
+    content_url = assemble_github_content_url(**repo_info)
+    result = re.sub(r"(src=\")(tex/[a-z0-9]*\.svg.*\")", rf"\1{content_url}/\2", readme)
+    return result
+
+
+if __name__ == '__main__':
+    write_readme(get_readme_with_github_urls())

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python build.py
+python setup.py sdist

--- a/setup.py
+++ b/setup.py
@@ -1,47 +1,14 @@
 import runpy
-import git
-import re
 import setuptools
 
 
 __version__ = runpy.run_path("split_normal/version.py")["__version__"]
 
 
-def get_readme(filename="README.md"):
+def read_readme(filename="README.md"):
     with open(filename, "r") as f:
         readme = f.read()
     return readme
-
-
-def get_repo_info():
-    info = dict()
-    repo = git.Repo(".git")
-    info['url'] = repo.remotes.origin.url
-    m = re.match(r"git@github.com:(.*)/(.*).git", info['url'])
-    info['namespace'] = m.group(1)
-    info['project'] = m.group(2)
-    info['commit'] = repo.head.commit.hexsha
-    info['branch'] = None
-    info['tag'] = None
-    if repo.head.is_detached:
-        info['tag'] = next((tag.name for tag in repo.tags if tag.commit == repo.head.commit))
-    else:
-        info['branch'] = repo.active_branch.name
-    return info
-
-
-def assemble_github_content_url(namespace, project, branch, tag, commit, **kwargs):
-    version = branch or tag or commit
-    content_url = f"https://raw.githubusercontent.com/{namespace}/{project}/{version}"
-    return content_url
-
-
-def get_readme_with_github_urls():
-    readme = get_readme()
-    repo_info = get_repo_info()
-    content_url = assemble_github_content_url(**repo_info)
-    result = re.sub(r"(src=\")(tex/[a-z0-9]*\.svg.*\")", rf"\1{content_url}/\2", readme)
-    return result
 
 
 setuptools.setup(
@@ -49,7 +16,7 @@ setuptools.setup(
     version=__version__,
     author="Tárik S. Salem",
     description="A tiny package implementing functions of the split normal distribution compatible with Numpy and JAX.",
-    long_description=get_readme_with_github_urls(),
+    long_description=read_readme(),
     long_description_content_type="text/markdown",
     url="https://github.com/probablyai/split-normal",
     packages=setuptools.find_packages(exclude=("tests", )),


### PR DESCRIPTION
Replacing relative for absolute URLs in the package description is done by altering the README file as a pre-build step. As a result, doesn't require any external dependencies.